### PR TITLE
bugfix: A raw response was returned with application/json; charset=utf-8

### DIFF
--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -67,7 +67,7 @@ class HttpClient
         $this->curl->setOptArray($options);
         $rawResponse = $this->curl->exec(1, true);
         $contentType = $this->curl->getInfo(CURLINFO_CONTENT_TYPE);
-        if ($contentType !== self::CONTENT_TYPE_JSON) {
+        if (strpos($contentType, self::CONTENT_TYPE_JSON) === false) {
             return $rawResponse;
         }
         $response = json_decode($rawResponse);

--- a/test/HttpClientTest.php
+++ b/test/HttpClientTest.php
@@ -96,6 +96,17 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider httpMethods
+     */
+    public function testCallWhenResponseIsJSONWithCharset($method, $options)
+    {
+        $response = (object) array('status' => 'OK');
+        $contentType = 'application/json; charset=utf-8';
+        $this->initCurlMock($options, json_encode(array('response' => $response)), $contentType);
+        $this->assertEquals($response, $this->http->call($method, $this->url, array('foo' => 'bar')));
+    }
+
+    /**
+     * @dataProvider httpMethods
      * @expectedException RuntimeException
      * @expectedExceptionMessage Unexpected response: Pew-pew!
      */


### PR DESCRIPTION
bugfix: A raw response was returned with "Content-Type: application/json; charset=utf-8"
This Content-Type is returned in NOAUTH responses
