### PR TITLE
Authentication failed without NOAUTH error id fixed

### DIFF
--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -77,7 +77,7 @@ class HttpClient
         $response = $response->response;
         if ('OK' == @$response->status) {
             return $response;
-        } elseif ('NOAUTH' == @$response->error_id) {
+        } elseif ('NOAUTH' == @$response->error_id || 'Authentication failed - not logged in' == @$response->error) {
             throw new TokenExpiredException($response);
         }
         throw new ServerException($response);

--- a/test/HttpClientTest.php
+++ b/test/HttpClientTest.php
@@ -147,6 +147,21 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider httpMethods
+     * @expectedException \F3\AppNexusClient\TokenExpiredException
+     */
+    public function testTokenExpiredWithErrorMessage($method, $options)
+    {
+        $response = (object) array(
+            'status' => 'OMG',
+            'error_id' => 'SYNTAX',
+            'error' => 'Authentication failed - not logged in'
+        );
+        $this->initCurlMock($options, json_encode(array('response' => $response)));
+        $this->http->call($method, $this->url, array('foo' => 'bar'));
+    }
+
+    /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Invalid method: BOO
      */


### PR DESCRIPTION
We have noticed that sometimes Appnexus returns a 401 error without NOAUTH error's id. 

An example:

POST /creative =>
`stdClass Object
(
    [response] => stdClass Object
        (
            [error_id] => SYNTAX
            [error] => Authentication failed - not logged in
            [error_code] => 
            [dbg_info] => stdClass Object
                (
                   ...
                )
            [start_element] => 0
            [num_elements] => 100
            [count] => 0
            [service] => creative
            [method] => POST
        )

)`

Maybe we should control 401 error code, for the moment this is working for us.
